### PR TITLE
Create an aptly::mirror defined type

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,10 @@ PuppetLint.configuration.send('disable_class_parameter_defaults')
 # http://puppet-lint.com/checks/class_inherits_from_params_class/
 PuppetLint.configuration.send('disable_class_inherits_from_params_class')
 
+# Don't wrap command unnecessarily.
+# http://puppet-lint.com/checks/80chars/
+PuppetLint.configuration.send('disable_80chars')
+
 exclude_paths = [
   "pkg/**/*",
   "vendor/**/*",

--- a/manifests/mirror.pp
+++ b/manifests/mirror.pp
@@ -1,0 +1,67 @@
+# == Define: aptly::mirror
+#
+# Create a mirror using `aptly mirror create`. It will not update, snapshot,
+# or publish the mirror for you, because it will take a long time and it
+# doesn't make sense to schedule these actions frequenly in Puppet.
+#
+# The parameters are intended to be analogous to `apt::source`.
+#
+# NB: This will not recreate the mirror if the params change! You will need
+# to manually `aptly mirror drop <name>` after also dropping all snapshot
+# and publish references.
+#
+# === Parameters
+#
+# [*location*]
+#   URL of the APT repo.
+#
+# [*key*]
+#   Import the GPG key into the `trustedkeys` keyring so that aptly can
+#   verify the mirror's manifests.
+#
+# [*release*]
+#   Distribution to mirror for.
+#   Default: `$::lsbdistcodename`
+#
+# [*repos*]
+#   Components to mirror. If an empty array then aptly will default to
+#   mirroring all components.
+#   Default: []
+#
+define aptly::mirror (
+  $location,
+  $key,
+  $release = $::lsbdistcodename,
+  $repos = [],
+) {
+  validate_array($repos)
+
+  $gpg_cmd = '/usr/bin/gpg --no-default-keyring --keyring trustedkeys.gpg'
+  $aptly_cmd = '/usr/bin/aptly mirror'
+  $exec_key_title = "aptly_mirror_key-${key}"
+
+  if empty($repos) {
+    $components_arg = ''
+  } else {
+    $components = join($repos, ' ')
+    $components_arg = " ${components}"
+  }
+
+  if !defined(Exec[$exec_key_title]) {
+    exec { $exec_key_title:
+      command => "${gpg_cmd} --keyserver 'keyserver.ubuntu.com' --recv-keys '${key}'",
+      unless  => "${gpg_cmd} --list-keys '${key}'",
+      user    => 'root',
+    }
+  }
+
+  exec { "aptly_mirror_create-${title}":
+    command => "${aptly_cmd} create ${title} ${location} ${release}${components_arg}",
+    unless  => "${aptly_cmd} show ${title} >/dev/null",
+    user    => 'root',
+    require => [
+      Class['aptly'],
+      Exec[$exec_key_title],
+    ],
+  }
+}

--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe 'aptly::mirror' do
+  let(:title) { 'example' }
+  let(:facts) {{
+    :lsbdistid       => 'Debian',
+    :lsbdistcodename => 'precise',
+  }}
+
+  describe 'param defaults and mandatory' do
+    let(:params) {{
+      :location => 'http://repo.example.com',
+      :key      => 'ABC123',
+    }}
+
+    it {
+      should contain_exec('aptly_mirror_key-ABC123').with({
+        :command => / --recv-keys 'ABC123'$/,
+        :unless  => / --list-keys 'ABC123'$/,
+        :user    => 'root',
+      })
+    }
+
+    it {
+      should contain_exec('aptly_mirror_create-example').with({
+        :command => /aptly mirror create example http:\/\/repo\.example\.com precise$/,
+        :unless  => /aptly mirror show example >\/dev\/null$/,
+        :user    => 'root',
+        :require => [
+          'Class[Aptly]',
+          'Exec[aptly_mirror_key-ABC123]'
+        ],
+      })
+    }
+
+    context 'two repos with same key' do
+      let(:pre_condition) { <<-EOS
+        aptly::mirror { 'example-lucid':
+          location => 'http://lucid.example.com/',
+          key      => 'ABC123',
+        }
+        EOS
+      }
+
+      it { should contain_exec('aptly_mirror_key-ABC123') }
+    end
+  end
+
+
+  describe '#repos' do
+    context 'not an array' do
+      let(:params) {{
+        :location => 'http://repo.example.com',
+        :key      => 'ABC123',
+        :repos    => 'this is a string',
+      }}
+
+      it { expect { should }.to raise_error(Puppet::Error, /is not an Array/) }
+    end
+
+    context 'single item' do
+      let(:params) {{
+        :location => 'http://repo.example.com',
+        :key      => 'ABC123',
+        :repos    => ['main'],
+      }}
+
+      it {
+        should contain_exec('aptly_mirror_create-example').with_command(
+          /aptly mirror create example http:\/\/repo\.example\.com precise main$/
+        )
+      }
+    end
+
+    context 'multiple items' do
+      let(:params) {{
+        :location => 'http://repo.example.com',
+        :key      => 'ABC123',
+        :repos    => ['main', 'contrib', 'non-free'],
+      }}
+
+      it {
+        should contain_exec('aptly_mirror_create-example').with_command(
+          /aptly mirror create example http:\/\/repo\.example\.com precise main contrib non-free$/
+        )
+      }
+    end
+  end
+end

--- a/spec/system/mirror_spec.rb
+++ b/spec/system/mirror_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper_system'
+
+describe 'mirror tests' do
+  it 'class should work without errors and be idempotent' do
+    pp = <<-EOS
+      class { 'apt': }
+      class { 'aptly': }
+
+      aptly::mirror { 'puppetlabs':
+        location => 'http://apt.puppetlabs.com/',
+        key      => '4BD6EC30',
+        release  => 'precise',
+        repos    => ['main', 'dependencies'],
+      }
+    EOS
+
+    puppet_apply(pp) do |r|
+      r.exit_code.should == 2
+      r.refresh
+      r.exit_code.should be_zero
+    end
+  end
+
+  it 'should have installed aptly' do
+    shell 'aptly mirror show puppetlabs' do |r|
+      r.stdout.should =~ /^Name: puppetlabs
+Archive Root URL: http:\/\/apt\.puppetlabs\.com\/
+Distribution: precise
+Components: main, dependencies$/
+      r.stderr.should be_empty
+      r.exit_code.should be_zero
+    end
+  end
+end


### PR DESCRIPTION
Per the class docs:

Create a mirror using `aptly mirror create`. It will not update, snapshot,
or publish the mirror for you, because it will take a long time and it
doesn't make sense to schedule these actions frequenly in Puppet.

It will also import the GPG key into the keyring that aptly defaults to.
