### PR TITLE
Sort config hash to appease Ruby 1.8

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,6 @@ class aptly (
 
   file { '/etc/aptly.conf':
     ensure  => file,
-    content => inline_template("<%= @config.to_pson %>\n"),
+    content => inline_template("<%= Hash[@config.sort].to_pson %>\n"),
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,7 @@ describe 'aptly' do
       it { expect { should }.to raise_error(Puppet::Error, /is not a Hash/) }
     end
 
-    context 'rootDir and architectures' do
+    context 'rootDir and architectures in non-alphabetical order' do
       let(:params) {{
         :config => {
           'rootDir'       => '/srv/aptly',
@@ -30,12 +30,12 @@ describe 'aptly' do
         },
       }}
 
-      it {
+      it 'should render JSON file with contents sorted by key' do
         should contain_file('/etc/aptly.conf').with_content(<<EOS
-{"rootDir":"/srv/aptly","architectures":["i386","amd64"]}
+{"architectures":["i386","amd64"],"rootDir":"/srv/aptly"}
 EOS
         )
-      }
+      end
     end
   end
 


### PR DESCRIPTION
Sort the config hash by the key name to appease Ruby 1.8 which doesn't
preserve the order of hashes. This was causing the matrix tests in TravisCI
to fail non-deterministically, such as PR #3.

We have to cast the type again by using `Hash[]` because `#sort` returns an
array of array pairs. Whilst `#to_pson` will convert back if the original
hash was populated, it won't if the hash was empty and just produces an
empty array of `[]` causing the previous test to fail.

I've changed the name of the tests to reflect the extra work they're doing.

---

/cc @alphagov/team-infrastructure-admins 
