### PR TITLE
Remove support/testing for Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ language: ruby
 before_install: rm Gemfile.lock || true
 script: bundle exec rake test
 rvm:
-  - 1.8.7
   - 1.9.3
 env:
   matrix:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2014-05-08 CURRENT
+- Remove support for Ruby 1.8
+
 2014-03-31 Release 0.0.1
 - First release
 - Basic install and config


### PR DESCRIPTION
This version of Ruby doesn't maintain the order of hashes which makes it
non-trivial to render the config hash in a way that doesn't vary on every
run. We're not using Ruby 1.8 and hopefully less other people are now. So
remove it.

---

This replaces an attempt in #4 and fixes tests in #3.

/cc @alphagov/team-infrastructure-admins 
