### PR TITLE
package_ensure param to override version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,10 @@
 #
 # === Parameters
 #
+# [*package_ensure*]
+#   Ensure parameter to pass to the package resource.
+#   Default: present
+#
 # [*config*]
 #   Hash of configuration options for `/etc/aptly.conf`.
 #   See http://www.aptly.info/#configuration
@@ -15,6 +19,7 @@
 #   Default: true
 #
 class aptly (
+  $package_ensure = present,
   $config = {},
   $repo = true,
 ) {
@@ -35,7 +40,7 @@ class aptly (
   }
 
   package { 'aptly':
-    ensure  => present,
+    ensure  => $package_ensure,
   }
 
   file { '/etc/aptly.conf':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -13,6 +13,22 @@ describe 'aptly' do
     it { should contain_file('/etc/aptly.conf').with_content("{}\n") }
   end
 
+  describe '#package_ensure' do
+    context 'present (default)' do
+      let(:params) {{ }}
+
+      it { should contain_package('aptly').with_ensure('present') }
+    end
+
+    context '1.2.3' do
+      let(:params) {{
+        :package_ensure => '1.2.3',
+      }}
+
+      it { should contain_package('aptly').with_ensure('1.2.3') }
+    end
+  end
+
   describe '#config' do
     context 'not a hash' do
       let(:params) {{


### PR DESCRIPTION
Allow the package version to be overridden so that an existing machine can
be upgraded to a newer version of Aptly.
