### PR TITLE
Remove component from repo README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@ aptly::mirror { 'puppetlabs':
 
 Create an aptly repository to host local packages:
 ```puppet
-aptly::repo{ 'mylocalrepo':
-  component => 'main'
-}
+aptly::repo{ 'mylocalrepo': }
 ```
 
 See the class and defined type documentation for advanced usage.


### PR DESCRIPTION
Because it matches the default and due to not working correctly with aptly
=< 0.5.0 we should make people look at the inline docs if they want to
customise it.
