### PR TITLE
Adding key_server optoin to aptly apt::source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@ class aptly (
   $package_ensure = present,
   $config = {},
   $repo = true,
+  $key_server = 'keys.gnupg.net',
 ) {
 
   validate_hash($config)
@@ -32,6 +33,7 @@ class aptly (
       location    => 'http://repo.aptly.info',
       release     => 'squeeze',
       repos       => 'main',
+      key_server  => $key_server,
       key         => '2A194991',
       include_src => false,
     }


### PR DESCRIPTION
As not all environment has 11371 port open, we are required to use port 80 to
download the keyring. Therefore it would be great to have an option to specify
the key_source location so that we can do hkp://keys.gnupg.net:80 instead
