### PR TITLE
Make apt::source usage work with latest version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,11 +69,13 @@ class aptly (
 
   if $repo {
     apt::source { 'aptly':
-      location   => 'http://repo.aptly.info',
-      release    => 'squeeze',
-      repos      => 'main',
-      key_server => $key_server,
-      key        => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460',
+      location => 'http://repo.aptly.info',
+      release  => 'squeeze',
+      repos    => 'main',
+      key      => {
+        id     => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460',
+        server => $key_server,
+      }
     }
 
     Apt::Source['aptly'] -> Class['apt::update'] -> Package['aptly']

--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,7 @@
    ],
   "dependencies": [
     {"name": "puppetlabs/stdlib", "version_requirement": ">=3.0.0 <4.13.0"},
-    {"name": "puppetlabs/apt", "version_requirement": ">=2.0.0 <2.3.0"}
+    {"name": "puppetlabs/apt", "version_requirement": ">=2.0.0 <5.0.0"}
   ],
   "project_page": "https://github.com/gds-operations/puppet-aptly"
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -38,7 +38,7 @@ describe 'aptly' do
 
       it "should override apt::source (somekeyserver.com)" do
         should contain_apt__source('aptly').with(
-          :key_server => 'somekeyserver.com',
+          :key => { 'id' => 'DF32BC15E2145B3FA151AED19E3E53F19C7DE460', 'server' => 'somekeyserver.com' },
         )
       end
     end


### PR DESCRIPTION
Since version 2.0.0 of the puppetlabs/apt module, the "key_server"
argument has been deprecated in favour of specifying a "key" hash. The
key_server parameter was removed completely in version 4.0.0 of the
module.

This changeset updates the apt::source resource block to use the new
style and bumps the supported version of the apt module up to include
the 4.x branch.