### PR TITLE
bump puppetlabs-stdlib and puppetlabs-apt

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,9 +2,9 @@ fixtures:
   repositories:
     stdlib:
       repo: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-      ref: "4.25.1"
+      ref: "v6.4.0"
     apt:
       repo: "https://github.com/puppetlabs/puppetlabs-apt.git"
-      ref: "4.5.0"
+      ref: "v7.5.0"
   symlinks:
     aptly: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.0.0 <5.0.0"
+      "version_requirement": ">=4.25.1 <7.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=4.0.0 <5.0.0"
+      "version_requirement": ">=4.0.0 <8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -13,7 +13,7 @@ RSpec.configure do |c|
   c.before :suite do
     puppet_install
     puppet_module_install(source: proj_root, module_name: 'aptly')
-    shell('puppet module install puppetlabs-stdlib')
-    shell('puppet module install puppetlabs-apt --version 2.2.0')
+    shell('puppet module install puppetlabs-stdlib --version 6.4.0')
+    shell('puppet module install puppetlabs-apt --version 7.5.0')
   end
 end


### PR DESCRIPTION
#89 is still an issue. I think there is at least one other merge request for this https://github.com/gds-operations/puppet-aptly/pull/90. This one bumps to current latest stable versions of those. It'd be fine if one of the other request was just updated/merged and this one closed. But I definitely think it'd be nice to have this change merged as soon as possible. Thanks.